### PR TITLE
Cleanup clippy `as` lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,14 @@ name = "ruddy"
 path = "src/lib.rs"
 
 [lints.clippy]
-as_conversions = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+char_lit_as_u8 = "warn"
+fn_to_numeric_cast = "warn"
+fn_to_numeric_cast_with_truncation = "warn"
+ptr_as_ptr = "warn"
+unnecessary_cast = "warn"
 
 [dependencies]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -69,7 +69,7 @@ macro_rules! derive_unchecked_from {
     };
     ($A:ident as $B:ident) => {
         impl UncheckedFrom<$A> for $B {
-            #[allow(clippy::as_conversions)]
+            #[allow(clippy::cast_possible_truncation)]
             fn unchecked_from(x: $A) -> Self {
                 debug_assert!($B::try_from(x).is_ok());
                 x as $B
@@ -95,7 +95,7 @@ mod tests {
     fn basic_successful_unchecked_conversions() {
         assert_eq!(u64::from(u16::MAX), u16::MAX.unchecked_into());
         assert_eq!(u64::from(u32::MAX), u32::MAX.unchecked_into());
-        assert_eq!(u64::from(u64::MAX), u64::MAX.unchecked_into());
+        assert_eq!(u64::MAX, u64::MAX.unchecked_into());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,14 @@ pub mod variable_id;
 
 /// A conversion function asserting that we are running on (at least) a 32-bit platform.
 #[inline(always)]
-#[allow(clippy::as_conversions)]
+#[allow(clippy::cast_possible_truncation)]
 pub fn usize_is_at_least_32_bits(x: u32) -> usize {
     x as usize
 }
 
 /// A conversion function asserting that we are running on (at least) a 64-bit platform.
 #[inline(always)]
-#[allow(clippy::as_conversions)]
+#[allow(clippy::cast_possible_truncation)]
 pub fn usize_is_at_least_64_bits(x: u64) -> usize {
     x as usize
 }

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -295,7 +295,7 @@ impl_from!(NodeId16 => NodeId64);
 impl_from!(NodeId32 => NodeId64);
 
 impl UncheckedFrom<NodeId32> for NodeId16 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: NodeId32) -> Self {
         Self(match id.0 {
             NodeId32::UNDEFINED => NodeId16::UNDEFINED,
@@ -311,7 +311,7 @@ impl UncheckedFrom<NodeId32> for NodeId16 {
 }
 
 impl UncheckedFrom<NodeId64> for NodeId16 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: NodeId64) -> Self {
         Self(match id.0 {
             NodeId64::UNDEFINED => NodeId16::UNDEFINED,
@@ -327,7 +327,7 @@ impl UncheckedFrom<NodeId64> for NodeId16 {
 }
 
 impl UncheckedFrom<NodeId64> for NodeId32 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: NodeId64) -> Self {
         Self(match id.0 {
             NodeId64::UNDEFINED => NodeId32::UNDEFINED,

--- a/src/task_cache.rs
+++ b/src/task_cache.rs
@@ -119,7 +119,7 @@ impl KnuthHash for u128 {
         combined.wrapping_mul(210306068529402873165736369884012333108)
     }
 
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn to_slot(self, log_size: u32) -> usize {
         // Here, we can assume the conversion is safe, because the size of the task cache
         // should not exceed 2^64, meaning the integer should have at most 64 bits after the shift.

--- a/src/variable_id.rs
+++ b/src/variable_id.rs
@@ -380,7 +380,7 @@ impl_from!(VarIdPacked16 => VarIdPacked64);
 impl_from!(VarIdPacked32 => VarIdPacked64);
 
 impl UncheckedFrom<VarIdPacked64> for VarIdPacked16 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: VarIdPacked64) -> Self {
         debug_assert!(
             id.fits_in_packed16(),
@@ -395,7 +395,7 @@ impl UncheckedFrom<VarIdPacked64> for VarIdPacked16 {
 }
 
 impl UncheckedFrom<VarIdPacked64> for VarIdPacked32 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: VarIdPacked64) -> Self {
         debug_assert!(
             id.fits_in_packed32(),
@@ -407,7 +407,7 @@ impl UncheckedFrom<VarIdPacked64> for VarIdPacked32 {
 }
 
 impl UncheckedFrom<VarIdPacked32> for VarIdPacked16 {
-    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
     fn unchecked_from(id: VarIdPacked32) -> Self {
         debug_assert!(
             id.fits_in_packed16(),
@@ -483,9 +483,7 @@ impl<A: VarIdPackedAny, B: VarIdPackedAny + Into<A>> AsVarId<A> for B {}
 pub struct VariableId(u64);
 
 impl VariableId {
-    #[allow(clippy::as_conversions)]
     pub const MAX_16_BIT_ID: u64 = VarIdPacked16::MAX_ID as u64;
-    #[allow(clippy::as_conversions)]
     pub const MAX_32_BIT_ID: u64 = VarIdPacked32::MAX_ID as u64;
     pub const MAX_64_BIT_ID: u64 = VarIdPacked64::MAX_ID;
 


### PR DESCRIPTION
Removed the `clippy::as_conversions` lint and replaced it by the specific lints that it enabled. This makes it easier to see why a particular piece of code is suspicious:

`0u64 as u16` would say "casting `u64` to `u16` may truncate the value" rather than "using a potentially dangerous silent `as` conversion".

Furthermore, I removed the `cast_lossless` clippy lint, which was in `as_conversions`. This allows us to use `as` when it is safe, which is useful in `const` contexts where `From` and `Into` are not available.